### PR TITLE
Reduce JWT expiry

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -20,7 +20,7 @@ def get_token():
       "iss": service_account_name,
       "sub": service_account_name,
       "aud": token_url,
-      "exp": datetime.now().timestamp() + 900,
+      "exp": datetime.now().timestamp() + 200,
       "jti": str(uuid4()),
     }
     signed_assertion = jwt.encode(payload=assertion, key=private_key, algorithm="RS256")


### PR DESCRIPTION
## Overview

Reduce the JWT expiry to match what we do in the Javascript sample:
https://github.com/CareEvolution/mydatahelps-rest-api-node-quickstart/blob/main/quickstart.js#L50

Minor issue, but code based on this sample is causing some log warnings on the server side since it's more than the recommended five minutes.

The JWT is used once to obtain an access token, so there is no need for a longer expiry. The server already takes into account clock skew.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
- [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

Slightly reduce the expiry to bring it in line with recommendations.
