### PR TITLE
Additional Participant Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ To run the app:
 If successful, the app will print out your token and number of participants in the console, like so:
 
 ```
-Obtained access token:
+Obtained service access token:
   YOUR TOKEN HERE
 
 Total Participants: 5
 ```
 
-The access token is only valid for a few minutes, but you can copy/paste it into a REST query tool of your choice to try out advanced queries.
+The service access token is only valid for a few minutes, but you can copy/paste it into a REST query tool of your choice to try out advanced queries.
+
+You can also edit the code to specify a participant identifier and get a participant access token for that participant. This token is only needed for [MyDataHelps Embeddables](https://developer.mydatahelps.org/embeddables), and is useful for testing with the [MyDataHelps Starter Kit](https://github.com/CareEvolution/MyDataHelpsStarterKit). 
 
 ## Troubleshooting
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -106,6 +106,7 @@ if participant_identifier != "YOUR_PARTICIPANT_IDENTIFIER":
   
       # NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
       # Most API use cases do NOT require a participant token.
-      scopes = "api user/*.read"
+      # Be sure to request the correct scope(s) for your needs.
+      scopes = "Participant:read SurveyAnswers:read"
       participant_access_token = get_participant_access_token(service_access_token, id, scopes)
       print(f'\nObtained participant access token for {id}: {participant_access_token}')

--- a/quickstart.py
+++ b/quickstart.py
@@ -89,22 +89,23 @@ print(f'Obtained service access token:\n{service_access_token}')
 url = f'/api/v1/administration/projects/{project_id}/participants'
 response = get_from_api(service_access_token, url)
 participants = response.json()['totalParticipants']
-print(f'\n\nTotal participants: {participants}')
+print(f'\nTotal participants: {participants}')
 
 # Get a specific participant by identifier. We disable 'raise_error' here
 # so we can handle the 404 case ourselves.
-participant_identifier = "PT-123"
-url = f'/api/v1/administration/projects/{project_id}/participants/{participant_identifier}'
-response = get_from_api(service_access_token, url, {}, False)
-if response.status_code == 404:
-  print(f'Participant {participant_identifier} not found.')
-else:
-  participant = response.json()
-  id = participant['id']
-  print(f'Participant {participant_identifier} found with MDH ID {id}')
+participant_identifier = "YOUR_PARTICIPANT_IDENTIFIER"
+if participant_identifier != "YOUR_PARTICIPANT_IDENTIFIER":
+    url = f'/api/v1/administration/projects/{project_id}/participants/{participant_identifier}'
+    response = get_from_api(service_access_token, url, {}, False)
+    if response.status_code == 404:
+      print(f'\nParticipant {participant_identifier} not found.')
+    else:
+      participant = response.json()
+      id = participant['id']
+      print(f'\nParticipant {participant_identifier} found with MDH ID {id}')
   
-  # NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
-  # Most API use cases do NOT require a participant token.
-  scopes = "api user/*.read"
-  participant_access_token = get_participant_access_token(service_access_token, id, scopes)
-  print(f'Obtained participant access token for {id}: {participant_access_token}')
+      # NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
+      # Most API use cases do NOT require a participant token.
+      scopes = "api user/*.read"
+      participant_access_token = get_participant_access_token(service_access_token, id, scopes)
+      print(f'\nObtained participant access token for {id}: {participant_access_token}')

--- a/quickstart.py
+++ b/quickstart.py
@@ -106,7 +106,9 @@ if participant_identifier != "YOUR_PARTICIPANT_IDENTIFIER":
   
       # NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
       # Most API use cases do NOT require a participant token.
-      # Be sure to request the correct scope(s) for your needs.
+      # Be sure to:
+      # 1. Use the internal ID field (from participant['id'] above) and NOT participant_identifier
+      # 2. Request the correct scope(s) for your needs.
       scopes = "Participant:read SurveyAnswers:read"
       participant_access_token = get_participant_access_token(service_access_token, id, scopes)
       print(f'\nObtained participant access token for {id}: {participant_access_token}')

--- a/quickstart.py
+++ b/quickstart.py
@@ -13,7 +13,7 @@ private_key = os.getenv('RKS_PRIVATE_KEY')
 service_account_name = os.getenv('RKS_SERVICE_ACCOUNT')
 project_id = os.getenv('RKS_PROJECT_ID')
 
-def get_token():
+def get_service_access_token():
     token_url = 'https://mydatahelps.org/identityserver/connect/token' 
 
     assertion = {
@@ -35,9 +35,9 @@ def get_token():
     return response.json()["access_token"]
 
 
-def get_from_api(
+# Query all participants
+def get_participants(
     access_token: str,
-    resource_url: str,
     query_params: Optional[Dict[str, str]] = None
 ) -> requests.Response:
     if query_params is None:
@@ -48,15 +48,43 @@ def get_from_api(
         "Accept": "application/json",
         "Content-Type":  "application/json; charset=utf-8"
     }
-    url = f'https://mydatahelps.org/api/v1/administration/projects/{project_id}{resource_url}'
+    url = f'https://mydatahelps.org/api/v1/administration/projects/{project_id}/participants'
 
     response = requests.get(url=url, params=query_params, headers=headers)
     response.raise_for_status()
     return response
 
-token = get_token()
-print(f'Obtained access token:\n{token}')
+# Query for a specific participant by participant identifier
+def get_participant(
+    access_token: str,
+    participant_identifier: str
+) -> requests.Response:
 
-data = get_from_api(token, '/participants')
+    headers = {
+        "Authorization": f'Bearer {access_token}',
+        "Accept": "application/json",
+        "Content-Type":  "application/json; charset=utf-8"
+    }
+    url = f'https://mydatahelps.org/api/v1/administration/projects/{project_id}/participants/{participant_identifier}'
+
+    response = requests.get(url=url, headers=headers)
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response
+    
+token = get_service_access_token()
+print(f'Obtained service access token:\n{token}')
+
+data = get_participants(token)
 participants = data.json()['totalParticipants']
 print(f'\n\nTotal participants: {participants}')
+
+participant_id = "PT-123"
+data = get_participant(token, participant_id)
+if data == None:
+  print(f'Participant {participant_id} not found.')
+else:
+  participant = data.json()
+  id = participant['id']
+  print(f'Participant {participant_id} found with MDH ID {id}')

--- a/quickstart.py
+++ b/quickstart.py
@@ -73,13 +73,15 @@ def get_participant(
     response.raise_for_status()
     return response
 
+# Get a participant access token for the specified participant
 def get_participant_access_token(
     service_access_token: str,
-    participant_id: str
+    participant_id: str,
+    scopes: str
 ):
 
     token_payload = {
-        "scope": "api user/*.read",
+        "scope": scopes,
         "grant_type": "delegated_participant",
         "participant_id": participant_id,
         "client_id": "MyDataHelps.DelegatedParticipant",
@@ -105,5 +107,8 @@ else:
   participant = data.json()
   id = participant['id']
   print(f'Participant {participant_id} found with MDH ID {id}')
-  participant_access_token = get_participant_access_token(service_access_token, id)
-  print(f'Obtained participant access token:\n{participant_access_token}')
+  
+  # Request only the necessary scopes.
+  scopes = "api user/*.read"
+  participant_access_token = get_participant_access_token(service_access_token, id, scopes)
+  print(f'Obtained participant access token for {id}: {participant_access_token}')

--- a/quickstart.py
+++ b/quickstart.py
@@ -12,6 +12,7 @@ load_dotenv()
 private_key = os.getenv('RKS_PRIVATE_KEY')
 service_account_name = os.getenv('RKS_SERVICE_ACCOUNT')
 project_id = os.getenv('RKS_PROJECT_ID')
+
 base_url = 'https://mydatahelps.org'
 token_url = f'{base_url}/identityserver/connect/token' 
 
@@ -79,6 +80,8 @@ def get_participant_access_token(
     response.raise_for_status()
     return response.json()["access_token"]
     
+
+# Get a service access token, needed for all API calls.
 service_access_token = get_service_access_token()
 print(f'Obtained service access token:\n{service_access_token}')
 


### PR DESCRIPTION
## Overview

- Added examples for querying for a ppt and getting a ppt access token.
- Minor clarifications, such as being explicit about service access token naming.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
- [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner